### PR TITLE
Fix docker image publish - don't append timestamp to version

### DIFF
--- a/docker/index.js
+++ b/docker/index.js
@@ -22,10 +22,8 @@ core.info(`current branch: ${currentBranch}`);
 const isSnapshot = !['master', 'main'].includes(currentBranch);
 if (isSnapshot) core.info('this is a snapshot release');
 
-const timestamp = Date.now();
-
 try {
-  const targetVersion = `${artifactVersion(version, currentBranch, isSnapshot)}-${timestamp}`;
+  const targetVersion = artifactVersion(version, currentBranch, isSnapshot);
   exec(`docker login -u ${username} -p ${password} ${host}`);
   core.info(`logged into ${host}`);
   exec(`docker build -f ${dockerfile} -t ${imageTag}:${targetVersion} ${context}`);
@@ -37,7 +35,7 @@ try {
 }
 
 if (!skipProvisioning) {
-  publishProvisioning(tychoPath, provisioningPath, provisioningArtifactUrl(username, password, host, path, name, version, currentBranch, isSnapshot, `-${timestamp}`))
+  publishProvisioning(tychoPath, provisioningPath, provisioningArtifactUrl(username, password, host, path, name, version, currentBranch, isSnapshot))
     .then(provisioningTargetUrl => core.setOutput('url', provisioningTargetUrl))
     .catch((e) => core.setFailed(e));
 }

--- a/utils/artifactory.spec.js
+++ b/utils/artifactory.spec.js
@@ -24,6 +24,14 @@ describe('artifactory', () => {
       provisioningUrl: 'https://bgalek:password!%40%23@company.artifactory/artifactory/allegro-snapshots-local/pl/allegro/opbox/opbox-web/1.0.0-my-branch-SNAPSHOT/opbox-web-1.0.0-my-branch-20210819.112606-1-provisioning.zip'
     },
     {
+      name: 'opbox-web',
+      version: '1.0.0',
+      branch: 'feature/OPBOX-42-branch',
+      snapshot: true,
+      deployUrl: 'https://bgalek:password@company.artifactory/artifactory/allegro-snapshots-local/pl/allegro/opbox/opbox-web/1.0.0-feature-OPBOX-42-branch-SNAPSHOT/opbox-web-1.0.0-feature-OPBOX-42-branch-20210819.112606-1-deploy.zip',
+      provisioningUrl: 'https://bgalek:password!%40%23@company.artifactory/artifactory/allegro-snapshots-local/pl/allegro/opbox/opbox-web/1.0.0-feature-OPBOX-42-branch-SNAPSHOT/opbox-web-1.0.0-feature-OPBOX-42-branch-20210819.112606-1-provisioning.zip'
+    },
+    {
       name: 'listing-mobile-bff',
       version: '1.0.0',
       branch: 'master',


### PR DESCRIPTION
2 changes:
* don't append timestamp to artifact version
* remove 'lowercasing' branch name (it's easier to read e.g. ticket names)